### PR TITLE
Fixes #5 - bug that completely broke book parsing.  We were ending up…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ from calibre.customize import InterfaceActionBase
 class XRayCreatorPlugin(InterfaceActionBase):
     name                = 'X-Ray Creator'
     description         = 'A plugin to create X-Ray files for MOBI books'
-    supported_platforms = ['windows']
+    supported_platforms = ['windows', 'osx', 'linux']
     author              = 'Samreen Zarroug & Alex Mayer'
     version             = (1, 1, 0)
     minimum_calibre_version = (2, 0, 0)

--- a/book_config.py
+++ b/book_config.py
@@ -330,9 +330,15 @@ class BookSettings(object):
     def aliases(self):
         return self._aliases
 
-    @aliases.setter
     def aliases(self, val):
-        self._aliases[val[0]] =  val[1].replace(', ', ',').split(',')
+        # 'aliases' is a string containing a comma separated list of aliases.  
+        #
+        # Split it, remove whitespace from each element, drop empty strings (strangely, split only does this if you don't specify a separator)
+        #
+        # so "" -> []  "foo,bar" and " foo   , bar " -> ["foo", "bar"]
+        label, aliases = val
+        aliases = [x.strip() for x in aliases.split(",") if x.strip()]
+        self._aliases[label] =  aliases
 
     def save(self):
         self._prefs['asin'] = self.asin


### PR DESCRIPTION
… with every character having an alias of "", and so the handling in BookParser.__init__ was setting self._aliases[""] = term.lower() - overwriting it each time.  The last character to be processed would remain being the character who had an alias of "", and so we get a huge number of matches for this character and none for any other.

szarroug: this fixes the problem I had been seeing, where I could never end up with a properly parsed book.  I suspect this was only broken in github version (perhaps 2.2), hence why most weren't seeing it.