### PR TITLE
Various fixes that were broken in github version

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ from calibre.customize import InterfaceActionBase
 class XRayCreatorPlugin(InterfaceActionBase):
     name                = 'X-Ray Creator'
     description         = 'A plugin to create X-Ray files for MOBI books'
-    supported_platforms = ['windows']
+    supported_platforms = ['windows', 'osx', 'linux']
     author              = 'Samreen Zarroug & Alex Mayer'
     version             = (1, 1, 0)
     minimum_calibre_version = (2, 0, 0)

--- a/book_config.py
+++ b/book_config.py
@@ -177,14 +177,14 @@ class BookConfigWidget(QDialog):
 
     def search_for_shelfari_url(self):
         url = None
-        if self.asin_edit.text != '' and self.asin_edit.text != 'ASIN not found':
-            url = self.book.search_shelfari(self.asin_edit.text)
+        if self.asin_edit.text() != '' and self.asin_edit.text() != 'ASIN not found':
+            url = self.book.search_shelfari(self.asin_edit.text())
         if not url:
             if self.book._prefs['asin'] != '':
                 url = self.book.search_shelfari(self.book._prefs['asin'])
         if not url:
             if self.book.title != 'Unknown' and self.book.author != 'Unknown':
-                url = self.book.search_shelfari(self.title_and_author)
+                url = self.book.search_shelfari(self.book.title_and_author)
         if url:
             self.update_aliases_button.setEnabled(True)
             self.book.shelfari_url = url
@@ -330,6 +330,7 @@ class BookSettings(object):
     def aliases(self):
         return self._aliases
 
+    @aliases.setter
     def aliases(self, val):
         # 'aliases' is a string containing a comma separated list of aliases.  
         #

--- a/book_config.py
+++ b/book_config.py
@@ -330,9 +330,15 @@ class BookSettings(object):
     def aliases(self):
         return self._aliases
 
-    @aliases.setter
     def aliases(self, val):
-        self._aliases[val[0]] =  val[1].replace(', ', ',').split(',')
+        # 'aliases' is a string containing a comma separated list of aliases.  
+        #
+        # Split it, remove whitespace from each element, drop empty strings (strangely, split only does this if you don't specify a separator)
+        #
+        # so "" -> []  "foo,bar" and " foo   , bar " -> ["foo", "bar"]
+        label, aliases = val
+        aliases = [x.strip() for x in aliases.split(",") if x.strip()]
+        self._aliases[label] =  aliases
 
     def save(self):
         self._prefs['asin'] = self.asin


### PR DESCRIPTION
Various things were broken in github version (and 2.2, maybe?) - most fundamentally the breakage that book parsing would not find occurrences correctly (it was finding a very large number for one entity, and none for the others).

I have *not* tested this on Windows, only OS X.  If you can test it, great, if not I'll test it under Virtual Box at some point.  Certainly wasn't testing before we release - would be enough to:
1) check that finding Kindle and copying files across still works (ie. both doesn't error and actually does something).
2) check that things "fail" correctly if no Kindle is found