### PR TITLE
Fix a few issues in the same bit of code

### DIFF
--- a/lib/book.py
+++ b/lib/book.py
@@ -510,12 +510,11 @@ class Book(object):
                     with open(info['device_book'], 'r+b') as stream:
                         mu = ASINUpdater(stream)
                         info['original_asin'], info['asin'] = mu.update(self._asin, info['format'])
-                    if info['original_asin'] is not info['asin']:
+                    if info['original_asin'] != info['asin']:
                         # if we changed the asin, update the image file name
-                        for dirName, subDirList, fileList in os.walk(info['device_book'].split(os.sep)[0]):
-                            for file in glob(os.path.join(dirName, '*%s*.jpg' % info['original_asin'])):
-                                new_name = file.replace(info['original_asin'], info['asin'])
-                                os.rename(file, new_name)
+                        thumbname_orig = os.path.join(device, "system", "thumbnails", "thumbnail_%s_EBOK_portrait.jpg" % (info['original_asin']))
+                        thumbname_new = thumbname_orig.replace(info['original_asin'], info['asin'])
+                        os.rename(thumbname_orig, thumbname_new)
                 except:
                     info['send_status'] = self.FAIL
                     info['status_message'] = self.FAILED_UNABLE_TO_UPDATE_ASIN


### PR DESCRIPTION
Fixes #20 - use existing 'device' variable to find the Kindle
Fixes #2 - fixed as I needed to modify this code anyway
Fixes a potential bug (use of "not is" instead of "!=")

Note: I have tested on OS X, but *not* Windows.  Can you check that still works?  Should be fine, we are using 'device' elsewhere, and that is the biggest change.

Also - any reason we needed to be doing the os.walk instead of just directly modifying the file?  If there is my fix might not work, but I couldn't see any reason not to explicitly name the file to rename.