### PR TITLE
Prevents _get_notable_clips running for long time

### DIFF
--- a/lib/book_parser.py
+++ b/lib/book_parser.py
@@ -4,7 +4,7 @@
 import os
 import re
 from struct import unpack, error
-from random import randrange
+from random import shuffle
 
 from calibre.ebooks.mobi import MobiError
 from calibre.ebooks.mobi.huffcdic import HuffReader
@@ -141,8 +141,10 @@ class BookParser(object):
         else:
             num_of_notable_clips = len(notable_clips) + num_excerpts
 
+        excerpts_available = range(0, num_excerpts)
+        shuffle(excerpts_available)
         while len(notable_clips) < num_of_notable_clips:
-            rand_excerpt = randrange(0, num_excerpts - 1) if num_excerpts > 1 else 1
+            rand_excerpt = excerpts_available.pop() if num_excerpts > 1 else 1
             if rand_excerpt not in notable_clips:
                 notable_clips.append(rand_excerpt)
 


### PR DESCRIPTION
Changed randomizing notable_clips to use preset list instead of just generating random numbers and hoping to get excerpts that are not already inserted into notable clips. I had one book that took over 30min using old implementation.